### PR TITLE
Make spigot plugin load at startup

### DIFF
--- a/TimoCloud-API/pom.xml
+++ b/TimoCloud-API/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.TimoCloud</groupId>
-        <version>6.3.2</version>
+        <version>6.3.3</version>
     </parent>
 
     <artifactId>TimoCloud-API</artifactId>

--- a/TimoCloud-Universal/pom.xml
+++ b/TimoCloud-Universal/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.TimoCloud</groupId>
-        <version>6.3.2</version>
+        <version>6.3.3</version>
     </parent>
 
     <repositories>

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/bukkit/managers/SignManager.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/bukkit/managers/SignManager.java
@@ -56,7 +56,7 @@ public class SignManager {
     };
 
     public SignManager() {
-        load();
+        Bukkit.getScheduler().runTask(TimoCloudBukkit.getInstance(), this::load);
     }
 
     public void load() {

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/bukkit/managers/SignManager.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/bukkit/managers/SignManager.java
@@ -20,6 +20,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/TimoCloud-Universal/src/main/resources/plugin.yml
+++ b/TimoCloud-Universal/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ author: TimoCrafter
 main: cloud.timo.TimoCloud.bukkit.TimoCloudBukkit
 api-version: 1.13
 softdepend: [Multiverse-Core]
+load: STARTUP
 commands:
   timocloudbukkit:
     aliases: [tcb]

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>cloud.timo.TimoCloud</groupId>
     <artifactId>TimoCloud</artifactId>
     <packaging>pom</packaging>
-    <version>6.3.2</version>
+    <version>6.3.3</version>
 
     <modules>
         <module>TimoCloud-Universal</module>


### PR DESCRIPTION
Makes the spigot plugin load at startup instead of when the worlds are loaded. Fixes plugins that also load at startup and depend on TimoCloud.