### PR TITLE
CloudFlareManager: delete existing records sync, to prevent missing b…

### DIFF
--- a/TimoCloud-API/pom.xml
+++ b/TimoCloud-API/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.timocloud</groupId>
-        <version>6.7.5</version>
+        <version>6.7.6</version>
     </parent>
 
     <artifactId>TimoCloud-API</artifactId>

--- a/TimoCloud-Staging/pom.xml
+++ b/TimoCloud-Staging/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>cloud.timo.timocloud</groupId>
         <artifactId>TimoCloud</artifactId>
-        <version>6.7.5</version>
+        <version>6.7.6</version>
     </parent>
 
     <artifactId>TimoCloud-Staging</artifactId>

--- a/TimoCloud-Universal/pom.xml
+++ b/TimoCloud-Universal/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.timocloud</groupId>
-        <version>6.7.5</version>
+        <version>6.7.6</version>
     </parent>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CloudFlareManager.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CloudFlareManager.java
@@ -118,24 +118,20 @@ public class CloudFlareManager implements Listener {
     }
 
     private void deleteExistingRecords() {
-        executorService.submit(() -> {
-            getZones().parallelStream().forEach(zone -> {
-                getRecords(zone).parallelStream().forEach(record -> {
-                    if (record.getName().contains(".base.")) {
-                        if (!createdRecords.contains(record)) {
-                            deleteRecord(record);
-                        }
-                    }
-                });
-            });
-        });
-        executorService.submit(() -> {
-            getActiveHostnames().parallelStream().forEach(hostname -> { // Delete SRV records
-                getMatchingSrvRecords(hostname, "SRV").parallelStream().forEach(record -> {
+        getZones().parallelStream().forEach(zone -> {
+            getRecords(zone).parallelStream().forEach(record -> {
+                if (record.getName().contains(".base.")) {
                     if (!createdRecords.contains(record)) {
                         deleteRecord(record);
                     }
-                });
+                }
+            });
+        });
+        getActiveHostnames().parallelStream().forEach(hostname -> { // Delete SRV records
+            getMatchingSrvRecords(hostname, "SRV").parallelStream().forEach(record -> {
+                if (!createdRecords.contains(record)) {
+                    deleteRecord(record);
+                }
             });
         });
     }
@@ -146,8 +142,6 @@ public class CloudFlareManager implements Listener {
             this.createdRecords.add(createdRecord);
             return createdRecord;
         } catch (Exception e) {
-            if (e.getMessage().contains("The record already exists."))
-                return null; // This happens when a base connects while we are deleting old records
             TimoCloudCore.getInstance().severe(e);
             return null;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>cloud.timo.timocloud</groupId>
     <artifactId>TimoCloud</artifactId>
     <packaging>pom</packaging>
-    <version>6.7.5</version>
+    <version>6.7.6</version>
 
     <name>TimoCloud</name>
     <description>TimoCloud is a Minecraft server/proxy management system ("Cloud System"). It will care about keeping


### PR DESCRIPTION
## Overview
If the base is started before the core module, the base dns record is unfortunately missing due to a race condition and the network cannot be reached. This was already recognized appropriately in the code (see comment), but was not further corrected. With this change, the one-time deletion will be carried out synchronously when the core module starts, so this problem can no longer occur.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/TimoCloud/TimoCloud/blob/master/CONTRIBUTING.md)
