### PR TITLE
Add start command

### DIFF
--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/HelpCommandHandler.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/HelpCommandHandler.java
@@ -21,6 +21,7 @@ public class HelpCommandHandler implements CommandHandler {
         sender.sendMessage("  &6removegroup &7<&2groupName&7> - &7deletes a group");
         sender.sendMessage("  &6editgroup &7<&2name&7> <&2onlineAmount &7(&9int&7) | &2maxAmount &7(&9int&7) | &2ram &7(&9int&7) | &2static &7(&9boolean&7) | &2priority &7(&9int&7) | &2base &7(&9String&7) | &2jrePath &7(&9String&7)> <&2value&7> - &7edits the give setting of a server group");
         sender.sendMessage("  &6editgroup &7<&2name&7> <&2playersPerProxy &7(&9int&7) | &2maxPlayers &7(&9int&7) | &2keepFreeSlots &7(&9int&7) | &2minAmount &7(&9int&7) | &2maxAmount &7(&9int&7) | &2ram &7(&9int&7) | &2static &7(&9boolean&7) | &2priority &7(&9int&7) | &2base &7(&9String&7) | &2jrePath &7(&9String&7)> <&2value&7> - &7edits the give setting of a proxy group");
+        sender.sendMessage("  &6start &7<&2groupName&7> - &7starts a server or proxy group");
         sender.sendMessage("  &6restart &7<&2groupName&7 | &2baseName&7 | &2serverName&7 | &2proxyName&7> - &7restarts the given group, base, server, or proxy (If a base, stops/restarts every server and proxy on the base)");
         sender.sendMessage("  &6groupinfo &7<&2groupName&7> - displays group info");
         sender.sendMessage("  &6listgroups &7- &7lists all groups and started servers");

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/StartCommandHandler.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/StartCommandHandler.java
@@ -1,0 +1,80 @@
+package cloud.timo.TimoCloud.core.commands;
+
+import cloud.timo.TimoCloud.api.core.commands.CommandHandler;
+import cloud.timo.TimoCloud.api.core.commands.CommandSender;
+import cloud.timo.TimoCloud.core.TimoCloudCore;
+import cloud.timo.TimoCloud.core.objects.*;
+
+
+public class StartCommandHandler implements CommandHandler {
+
+    @Override
+    public void onCommand(String command, CommandSender sender, String... args) {
+        if (args.length != 1) {
+            sender.sendError("Usage: start <groupName>");
+            return;
+        }
+
+        String groupName = args[0];
+        Group group = TimoCloudCore.getInstance().getInstanceManager().getGroupByName(groupName);
+
+        if (group == null) {
+            sender.sendError("Group '" + groupName + "' not found.");
+            return;
+        }
+
+        if (group instanceof ServerGroup) {
+            startServer((ServerGroup) group, sender);
+        } else if (group instanceof ProxyGroup) {
+            startProxy((ProxyGroup) group, sender);
+        }
+    }
+
+    private void startServer(ServerGroup serverGroup, CommandSender sender) {
+        if (serverGroup.getMaxAmount() > 0 && serverGroup.getServers().size() >= serverGroup.getMaxAmount()) {
+            sender.sendError("Server group '" + serverGroup.getName() + "' has already reached its maximum amount of " + serverGroup.getMaxAmount() + " servers.");
+            return;
+        }
+
+        Base base = TimoCloudCore.getInstance().getInstanceManager().getFreeBase(serverGroup);
+        if (base == null) {
+            if (serverGroup.getBase() != null) {
+                sender.sendError("Base '" + serverGroup.getBase().getName() + "' is not available or does not have enough resources.");
+            } else {
+                sender.sendError("No available base found for server group '" + serverGroup.getName() + "'.");
+            }
+            return;
+        }
+
+        Server server = TimoCloudCore.getInstance().getInstanceManager().startServerManually(serverGroup, base);
+        if (server != null) {
+            sender.sendMessage("&aStarting server '" + server.getName() + "' from group '" + serverGroup.getName() + "'...");
+        } else {
+            sender.sendError("Failed to start server from group '" + serverGroup.getName() + "'.");
+        }
+    }
+
+    private void startProxy(ProxyGroup proxyGroup, CommandSender sender) {
+        if (proxyGroup.getMaxAmount() > 0 && proxyGroup.getProxies().size() >= proxyGroup.getMaxAmount()) {
+            sender.sendError("Proxy group '" + proxyGroup.getName() + "' has already reached its maximum amount of " + proxyGroup.getMaxAmount() + " proxies.");
+            return;
+        }
+
+        Base base = TimoCloudCore.getInstance().getInstanceManager().getFreeBase(proxyGroup);
+        if (base == null) {
+            if (proxyGroup.getBase() != null) {
+                sender.sendError("Base '" + proxyGroup.getBase().getName() + "' is not available or does not have enough resources.");
+            } else {
+                sender.sendError("No available base found for proxy group '" + proxyGroup.getName() + "'.");
+            }
+            return;
+        }
+
+        Proxy proxy = TimoCloudCore.getInstance().getInstanceManager().startProxyManually(proxyGroup, base);
+        if (proxy != null) {
+            sender.sendMessage("&aStarting proxy '" + proxy.getName() + "' from group '" + proxyGroup.getName() + "'...");
+        } else {
+            sender.sendError("Failed to start proxy from group '" + proxyGroup.getName() + "'.");
+        }
+    }
+}

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CommandManager.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CommandManager.java
@@ -63,6 +63,7 @@ public class CommandManager {
         registerCommand(new VersionCommandHandler(), "version", "info");
         registerCommand(new AddBaseCommandHandler(), "addbase");
         registerCommand(new EditBaseCommandHandler(), "editbase");
+        registerCommand(new StartCommandHandler(), "start", "startgroup");
     }
 
     public void sendHelp(CommandSender sender) {

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CoreInstanceManager.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CoreInstanceManager.java
@@ -418,6 +418,17 @@ public class CoreInstanceManager {
     }
 
     /**
+     * Manually starts a new server instance of a server group (for start command)
+     *
+     * @param group The group of which an instance shall be started
+     * @param base  The base an the server shall be started on
+     * @return The started server
+     */
+    public Server startServerManually(ServerGroup group, Base base) {
+        return startServer(group, base);
+    }
+
+    /**
      * @param group The group the maps shall be searched in
      * @return A list of available map templates
      */
@@ -457,6 +468,17 @@ public class CoreInstanceManager {
         Proxy proxy = new Proxy(name, id, base, group);
         proxy.start();
         return proxy;
+    }
+
+    /**
+     * Manually starts a new proxy instance of a proxy group (for start command)
+     *
+     * @param group The group of which an instance shall be started
+     * @param base  The base an the proxy shall be started on
+     * @return The started proxy
+     */
+    public Proxy startProxyManually(ProxyGroup group, Base base) {
+        return startProxy(group, base);
     }
 
     /**


### PR DESCRIPTION
## Overview

Explanation in the issue

**Fixes #148**

## Description

This pull request adds the start command to manually start server groups that should not remain permanently switched on, e.g. static servers.

The `max-amount` limit is taken into account in the start command so that not too many are created, and the code conventions are also adhered to.

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/TimoCloud/TimoCloud/blob/master/CONTRIBUTING.md)
